### PR TITLE
Send events directly to libraries.io

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source 'https://rubygems.org'
 ruby '2.4.0'
 
 gem 'em-eventsource'
-gem 'sidekiq'
-gem 'redis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,6 @@ GEM
   specs:
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
-    concurrent-ruby (1.0.5)
-    connection_pool (2.2.1)
     cookiejar (0.3.3)
     em-eventsource (0.2.1)
       em-http-request (~> 1.0)
@@ -20,26 +18,15 @@ GEM
     eventmachine (1.2.3)
     http_parser.rb (0.6.0)
     public_suffix (2.0.5)
-    rack (2.0.1)
-    rack-protection (1.5.3)
-      rack
-    redis (3.3.3)
-    sidekiq (4.2.9)
-      concurrent-ruby (~> 1.0)
-      connection_pool (~> 2.2, >= 2.2.0)
-      rack-protection (>= 1.5.0)
-      redis (~> 3.2, >= 3.2.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   em-eventsource
-  redis
-  sidekiq
 
 RUBY VERSION
    ruby 2.4.0p0
 
 BUNDLED WITH
-   1.14.5
+   1.14.6

--- a/dispatch.rb
+++ b/dispatch.rb
@@ -1,8 +1,25 @@
 require 'em-eventsource'
-require 'sidekiq'
+require 'json'
+
+class EventSender
+  def initialize
+    @connection = EventMachine::HttpRequest.new(ENV["EVENT_HOOK_URL"])
+  end
+
+  def send_event(name, params = {})
+    @connection.post({
+      body: JSON.dump(params),
+      head: {
+        "Content-Type" => "application/json",
+        "X-GitHub-Event" => name
+      }
+    })
+  end
+end
 
 EM.run do
   source = EM::EventSource.new(ENV["FIREHOSE_URL"])
+  sender = EventSender.new
 
   source.error do |error|
     puts "error #{error}"
@@ -10,46 +27,66 @@ EM.run do
 
   source.on "event" do |message|
     data = JSON.parse(message)
+
     case data['type']
     when 'RepositoryEvent'
       p 'RepositoryEvent'
-      Sidekiq::Client.push('queue' => 'low', 'class' => 'CreateRepositoryWorker', 'args' => ['GitHub', data['repo']['name'], nil])
+      sender.send_event(
+        'repository', {
+          "repository" => { "full_name" => data['repo']['name'] }
+      })
     when 'WatchEvent'
       p 'star'
-      Sidekiq::Client.push('queue' => 'low', 'class' => 'GithubStarWorker', 'args' => [data['repo']['name'], nil])
+      sender.send_event('watch', {
+        "repository" => { "full_name" => data['repo']['name'] }
+      })
     when 'PublicEvent'
-      p 'pubic'
-      Sidekiq::Client.push('queue' => 'low', 'class' => 'CreateRepositoryWorker', 'args' => ['GitHub', data['repo']['name'], nil])
+      p 'public'
+      sender.send_event(
+        'public', {
+          "repository" => { "full_name" => data['repo']['name'] }
+      })
     when 'ReleaseEvent'
       p 'new release'
-      Sidekiq::Client.push('queue' => 'low', 'class' => 'CreateRepositoryWorker', 'args' => ['GitHub', data['repo']['name'], nil])
+      sender.send_event(
+        'release', {
+          "repository" => { "full_name" => data['repo']['name'] }
+      })
     when 'ForkEvent'
       p 'new fork'
       # Sidekiq::Client.push('queue' => 'low', 'class' => 'CreateRepositoryWorker', 'args' => ['GitHub', data['repo']['name'], nil])
     when 'IssuesEvent'
-      case data['payload']['action']
-      when 'opened', 'closed', 'reopened', 'labeled', 'unlabeled', 'edited'
-        p "Issue #{data['payload']['action']} #{data['repo']['name']}"
-        Sidekiq::Client.push('queue' => 'low', 'class' => 'IssueWorker', 'args' => [data['repo']['name'], data['payload']['issue']['number'],nil])
-      end
+      p "Issue #{data['payload']['action']} #{data['repo']['name']}"
+      sender.send_event(
+        'issues', {
+          "action" => data['payload']['action'],
+          "issue" => { "number" => data['payload']['issue']['number'] },
+          "repository" => { 'id' => data['repo']['id'], "full_name" => data['repo']['name'] },
+          'sender' => { 'id' => data['actor']['id'] }
+      })
     when 'PullRequestEvent'
-      case data['payload']['action']
-      when 'opened', 'closed', 'reopened', 'labeled', 'unlabeled', 'edited'
-        p "Pull Request #{data['payload']['action']} #{data['repo']['name']}"
-        Sidekiq::Client.push('queue' => 'low', 'class' => 'IssueWorker', 'args' => [data['repo']['name'], data['payload']['pull_request']['number'], nil])
-      end
+      p "Pull Request #{data['payload']['action']} #{data['repo']['name']}"
+      sender.send_event(
+        'pull_request', {
+          "action" => data['payload']['action'],
+          "pull_request" => { "number" => data['payload']['pull_request']['number'] },
+          "repository" => { 'id' => data['repo']['id'], "full_name" => data['repo']['name'] },
+          'sender' => { 'id' => data['actor']['id'] }
+      })
     when 'IssueCommentEvent'
       p 'new issue comment'
-      Sidekiq::Client.push('queue' => 'low', 'class' => 'IssueWorker', 'args' => [data['repo']['name'], data['payload']['issue']['number'],nil])
+      sender.send_event(
+        'issue_comment', {
+          "repository" => { "full_name" => data['repo']['name'] },
+          "issue" => { "number" => data['payload']['issue']['number'] }
+        }
+      )
     when 'CreateEvent'
-      thing = data['payload']['ref_type']
-      if thing == 'tag'
-        p 'new tag'
-        Sidekiq::Client.push('queue' => 'low', 'class' => 'TagWorker', 'args' => [data['repo']['name'], nil])
-      elsif thing == 'repository'
-        p 'new repo'
-        Sidekiq::Client.push('queue' => 'low', 'class' => 'CreateRepositoryWorker', 'args' => ['GitHub', data['repo']['name'], nil])
-      end
+      p 'new create'
+      sender.send_event('create', {
+        'ref_type' => data['payload']['ref_type'],
+        "repository" => { "full_name" => data['repo']['name'] }
+      })
     end
   end
 


### PR DESCRIPTION
The requests match those sent from the official GitHub API.

Removes the Sidekiq / Redis dependencies.

cc @andrew 